### PR TITLE
Enable linux_arm64 build on release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,7 @@ builds:
       - darwin_amd64
       - darwin_arm64
       - linux_amd64
+      - linux_arm64
 
     flags:
       - -buildvcs=false

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin also aims to facilitate this in a tightly controlled way in order to
 Prebuilt binaries for several architectures can be found attached to any of the available [releases][github-release-link].
 
 ```shell
-$ wget https://github.com/joshdk/template-transformer/releases/download/v0.2.1/template-transformer-linux-amd64.tar.gz
+$ wget https://github.com/joshdk/template-transformer/releases/download/v0.2.2/template-transformer-linux-amd64.tar.gz
 $ tar -xf template-transformer-linux-amd64.tar.gz
 $ mkdir -p ${XDG_CONFIG_HOME}/kustomize/plugin/jdk.sh/v1beta1/templatetransformer/
 $ install TemplateTransformer ${XDG_CONFIG_HOME}/kustomize/plugin/jdk.sh/v1beta1/templatetransformer/TemplateTransformer


### PR DESCRIPTION
Currently the transformer is only build for darwin_arm if we want to run it on arm. This PR simply adds a line in goreleaser to support linux_arm too.